### PR TITLE
Fallback to using specified protocol in secure mode

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -111,7 +111,9 @@ proto._connect = function _connect(options, callback) {
 
     var protocol;
     if (state.secure)
-      protocol = socket.npnProtocol || socket.alpnProtocol;
+      protocol = socket.npnProtocol ||
+                 socket.alpnProtocol ||
+                 state.options.protocol;
     else
       protocol = state.options.protocol;
 


### PR DESCRIPTION
On older versions of node with no ALPN support, socket.npnProtocol is
returned as undefined, resulting in the activation of fallback mode.
This commit allows for falling back to a user-defined protocol in case
NPN/ALPN extensions aren't available.
