### PR TITLE
Fixes agent to handle incoming responses correctly

### DIFF
--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -30,6 +30,9 @@ function Handle(options, stream, socket) {
   if (!state.stream) {
     this.on('stream', function(stream) {
       state.stream = stream;
+      stream.on('end', function() {
+        state.ending = true;
+      });
     });
   }
 }


### PR DESCRIPTION
Currently, the node-spdy agent seems to emit an "aborted" event on every
incoming response because the `ending` flag isn't set for agent streams.
This commit sets the `ending` flag to true for agent streams.

Fixes #281
