### PR TITLE
Fix memory leak caused by misfiring callback

### DIFF
--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -52,10 +52,20 @@ Handle.prototype._getPeerName = function _getPeerName() {
 Handle.prototype._closeCallback = function _closeCallback(callback) {
   var state = this._spdyState;
 
-  if (state.ending)
-    state.stream.end(callback);
-  else
+  if (state.ending) {
+    // The .end() method may be called by us (in the else condition below) or
+    // by the .shutdown() method in out super-class. If the latter has already
+    // been called, then calling the .end() method below will have no effect,
+    // with the result that the callback will never get executed, resulting in
+    // an ever so subtle memory leak.
+    if (state.stream.isServer && state.stream._writableState.ending) {
+      process.nextTick(callback);
+    } else {
+      state.stream.end(callback);
+    }
+  } else {
     state.stream.abort(callback);
+  }
 
   // Only a single end is allowed
   state.ending = false;


### PR DESCRIPTION
Streams can be ended by calling the `.close()` or `.shutdown()` methods
on the Handle instances. Internally, both call the `.end()` method to
end the stream. However, only the `.close()` method takes a callback
that eventually frees the HttpParser instance allocated to the stream
socket.

In the event that the `.shutdown()` method is called before calling the
`.close()` method, the second call to `.end()` never fires the callback,
resulting in the leaking of HttpParser instances along with all its
references.

This commit fixes the issue by executing the callback provided to the
`.close()` method in the event the `.shutdown()` method was called
before the call to calling `.close()`.
