### PR TITLE
Fix memory leak caused by misfiring callback

### DIFF
--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -51,11 +51,22 @@ Handle.prototype._getPeerName = function _getPeerName() {
 
 Handle.prototype._closeCallback = function _closeCallback(callback) {
   var state = this._spdyState;
+  var stream = state.stream;
 
-  if (state.ending)
-    state.stream.end(callback);
-  else
-    state.stream.abort(callback);
+  if (state.ending) {
+    // The .end() method of the stream may be called by us or by the
+    // .shutdown() method in our super-class. If the latter has already been
+    // called, then calling the .end() method below will have no effect, with
+    // the result that the callback will never get executed, leading to an ever
+    // so subtle memory leak.
+    if (stream._spdyState.isServer && stream._writableState.ending) {
+      process.nextTick(callback);
+    } else {
+      stream.end(callback);
+    }
+  } else {
+    stream.abort(callback);
+  }
 
   // Only a single end is allowed
   state.ending = false;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -91,4 +91,3 @@ exports.everyConfig = function everyConfig(body) {
     });
   });
 }
-

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -115,10 +115,12 @@ describe('SPDY Server', function() {
         assert.equal(req.method, 'POST');
         assert.equal(req.url, '/post');
 
-        res.writeHead(200, {
-          ok: 'yes'
-        });
-        res.end('response');
+        setTimeout(function() {
+          res.writeHead(200, {
+            ok: 'yes'
+          });
+          res.end('response');
+        }, 10);
 
         fixtures.expectData(req, 'request', next);
       });
@@ -207,18 +209,20 @@ describe('SPDY Server', function() {
         assert.equal(req.method, 'POST');
         assert.equal(req.url, '/page');
 
-        res.writeHead(200, {
-          ok: 'yes'
-        });
+        setTimeout(function() {
+          res.writeHead(200, {
+            ok: 'yes'
+          });
 
-        var push = res.push('/push', {
-          request: {
-            yes: 'push'
-          }
-        });
-        push.end('push');
+          var push = res.push('/push', {
+            request: {
+              yes: 'push'
+            }
+          });
+          push.end('push');
 
-        res.end('response');
+          res.end('response');
+        }, 10);
 
         fixtures.expectData(req, 'request', next);
       });


### PR DESCRIPTION
Streams can be ended by calling the `.close()` or `.shutdown()` methods
on the Handle instances. Internally, both call the `.end()` method to
end the stream. However, only the `.close()` method takes a callback
that eventually frees the HttpParser instance allocated to the stream
socket.

In the event that the `.shutdown()` method is called before calling the
`.close()` method, the second call to `.end()` never fires the callback,
resulting in the leaking of HttpParser instances along with all its
references.

This commit fixes the issue by directly executing the callback provided
to the `.close()` method in the event the `.shutdown()` method was
called before the `.close()` method of the Handle instance.
