### PR TITLE
Add checks for GOAWAY conditions on the agent

### DIFF
--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -148,12 +148,17 @@ Handle.prototype.assignClientRequest = function assignClientRequest(req) {
 
     // It is very important to leave this here, otherwise it will be executed
     // on a next tick, after `_send` will perform write
-    self.getStream(function(stream) {
-      stream.send();
+    self.getStream(function (stream) {
+      if (!stream.connection._isGoaway(stream.id))
+        stream.send();
     });
 
     // We are ready to create stream
     self.emit('needStream');
+
+    // Ensure that the connection is still ok to use
+    if (state.stream && state.stream.connection._isGoaway(state.stream.id))
+      return;
 
     req._send = oldSend;
 

--- a/lib/spdy/socket.js
+++ b/lib/spdy/socket.js
@@ -18,6 +18,7 @@ function Socket(parent, options) {
   this.authorized = parent.authorized;
   this.authorizationError = parent.authorizationError;
   this.encrypted = true;
+  this.allowHalfOpen = true;
 }
 util.inherits(Socket, net.Socket);
 


### PR DESCRIPTION
Under certain conditions, it is possible for the code to send frames
AFTER a remote server has sent a GOAWAY frame. This commit fixes the
problem.