### PR TITLE
Handle connection-level errors correctly on agents

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -147,6 +147,12 @@ proto._connect = function _connect(options, callback) {
       return;
     }
 
+    var self = this;
+    connection.on('error', function(err) {
+      socket.destroy();
+      self.emit('error', err);
+    });
+
     if (state.options['x-forwarded-for'] !== undefined)
       connection.sendXForwardedFor(state.options['x-forwarded-for']);
 


### PR DESCRIPTION
The old code was missing a handler for the connection-level "error"
events. This commit adds an error-handler that re-emits the "error"
on the agent that user-code can handle as needed