### PR TITLE
deceiver+handle-thing: fix method lookup and -4095 EOF crash on Node 16+

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -94,6 +94,7 @@ proto._getCreateSocket = function _getCreateSocket () {
 }
 
 proto._connect = function _connect (options, callback) {
+  var self = this
   var state = this._spdyState
 
   var protocols = state.options.protocols || [
@@ -157,6 +158,10 @@ proto._connect = function _connect (options, callback) {
       callback(new Error('Unexpected protocol: ' + protocol))
       return
     }
+
+    connection.on('error', function (err) {
+      self.emit('error', err)
+    })
 
     if (state.options['x-forwarded-for'] !== undefined) {
       connection.sendXForwardedFor(state.options['x-forwarded-for'])

--- a/lib/spdy/deceiver.js
+++ b/lib/spdy/deceiver.js
@@ -1,0 +1,270 @@
+// Vendored from http-deceiver@1.2.7 (indutny/http-deceiver, MIT).
+// Two changes from upstream:
+//   1. The `process.binding('http_parser')` block is wrapped in try/catch
+//      and falls back to `mode = 'unsupported'`. The internal binding was
+//      removed in Node 16+ ("No such module: http_parser"); upstream is
+//      abandoned. The fallback uses string event names instead of integer
+//      kOn* indices and works for spdy's purposes.
+//   2. `new Buffer(0)` -> `Buffer.alloc(0)` (the legacy form is removed in
+//      modern Node).
+
+var assert = require('assert')
+
+var Buffer = require('buffer').Buffer
+
+// Node.js version
+var mode = /^v0\.8\./.test(process.version) ? 'rusty'
+  : /^v0\.(9|10)\./.test(process.version) ? 'old'
+  : /^v0\.12\./.test(process.version) ? 'normal'
+  : 'modern'
+
+var HTTPParser
+
+var methods
+var reverseMethods
+
+var kOnHeaders
+var kOnHeadersComplete
+var kOnMessageComplete
+var kOnBody
+
+if (mode === 'normal' || mode === 'modern') {
+  try {
+    HTTPParser = process.binding('http_parser').HTTPParser
+    methods = HTTPParser.methods
+
+    // v6
+    if (!methods) {
+      methods = process.binding('http_parser').methods
+    }
+
+    reverseMethods = {}
+
+    methods.forEach(function (method, index) {
+      reverseMethods[method] = index
+    })
+
+    kOnHeaders = HTTPParser.kOnHeaders | 0
+    kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0
+    kOnMessageComplete = HTTPParser.kOnMessageComplete | 0
+    kOnBody = HTTPParser.kOnBody | 0
+  } catch (e) {
+    mode = 'unsupported'
+  }
+}
+if (mode !== 'normal' && mode !== 'modern') {
+  kOnHeaders = 'onHeaders'
+  kOnHeadersComplete = 'onHeadersComplete'
+  kOnMessageComplete = 'onMessageComplete'
+  kOnBody = 'onBody'
+}
+
+function Deceiver (socket, options) {
+  this.socket = socket
+  this.options = options || {}
+  this.isClient = this.options.isClient
+}
+module.exports = Deceiver
+
+Deceiver.create = function create (stream, options) {
+  return new Deceiver(stream, options)
+}
+
+Deceiver.prototype._toHeaderList = function _toHeaderList (object) {
+  var out = []
+  var keys = Object.keys(object)
+
+  for (var i = 0; i < keys.length; i++) {
+    out.push(keys[i], object[keys[i]])
+  }
+
+  return out
+}
+
+Deceiver.prototype._isUpgrade = function _isUpgrade (request) {
+  return request.method === 'CONNECT' ||
+         request.headers.upgrade ||
+         (request.headers.connection &&
+            /(^|\W)upgrade(\W|$)/i.test(request.headers.connection))
+}
+
+// TODO(indutny): support CONNECT
+if (mode === 'modern') {
+  /*
+  function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
+                                   url, statusCode, statusMessage, upgrade,
+                                   shouldKeepAlive) {
+   */
+  Deceiver.prototype.emitRequest = function emitRequest (request) {
+    var parser = this.socket.parser
+    assert(parser, 'No parser present')
+
+    parser.execute = null
+
+    var self = this
+    var method = reverseMethods[request.method]
+    parser.execute = function execute () {
+      self._skipExecute(this)
+      this[kOnHeadersComplete](1,
+                               1,
+                               self._toHeaderList(request.headers),
+                               method,
+                               request.path,
+                               0,
+                               '',
+                               self._isUpgrade(request),
+                               true)
+      return 0
+    }
+
+    this._emitEmpty()
+  }
+
+  Deceiver.prototype.emitResponse = function emitResponse (response) {
+    var parser = this.socket.parser
+    assert(parser, 'No parser present')
+
+    parser.execute = null
+
+    var self = this
+    parser.execute = function execute () {
+      self._skipExecute(this)
+      this[kOnHeadersComplete](1,
+                               1,
+                               self._toHeaderList(response.headers),
+                               response.path,
+                               response.code,
+                               response.status,
+                               response.reason || '',
+                               self._isUpgrade(response),
+                               true)
+      return 0
+    }
+
+    this._emitEmpty()
+  }
+} else {
+  /*
+    `function parserOnHeadersComplete(info) {`
+
+    info = { .versionMajor, .versionMinor, .url, .headers, .method,
+             .statusCode, .statusMessage, .upgrade, .shouldKeepAlive }
+   */
+  Deceiver.prototype.emitRequest = function emitRequest (request) {
+    var parser = this.socket.parser
+    assert(parser, 'No parser present')
+
+    var method = request.method
+    if (reverseMethods) {
+      method = reverseMethods[method]
+    }
+
+    var info = {
+      versionMajor: 1,
+      versionMinor: 1,
+      url: request.path,
+      headers: this._toHeaderList(request.headers),
+      method: method,
+      statusCode: 0,
+      statusMessage: '',
+      upgrade: this._isUpgrade(request),
+      shouldKeepAlive: true
+    }
+
+    var self = this
+    parser.execute = function execute () {
+      self._skipExecute(this)
+      this[kOnHeadersComplete](info)
+      return 0
+    }
+
+    this._emitEmpty()
+  }
+
+  Deceiver.prototype.emitResponse = function emitResponse (response) {
+    var parser = this.socket.parser
+    assert(parser, 'No parser present')
+
+    var info = {
+      versionMajor: 1,
+      versionMinor: 1,
+      url: response.path,
+      headers: this._toHeaderList(response.headers),
+      method: false,
+      statusCode: response.status,
+      statusMessage: response.reason || '',
+      upgrade: this._isUpgrade(response),
+      shouldKeepAlive: true
+    }
+
+    var self = this
+    parser.execute = function execute () {
+      self._skipExecute(this)
+      this[kOnHeadersComplete](info)
+      return 0
+    }
+
+    this._emitEmpty()
+  }
+}
+
+Deceiver.prototype._skipExecute = function _skipExecute (parser) {
+  var self = this
+  var oldExecute = parser.constructor.prototype.execute
+  var oldFinish = parser.constructor.prototype.finish
+
+  parser.execute = null
+  parser.finish = null
+
+  parser.execute = function execute (buffer, start, len) {
+    // Parser reuse
+    if (this.socket !== self.socket) {
+      this.execute = oldExecute
+      this.finish = oldFinish
+      return this.execute(buffer, start, len)
+    }
+
+    if (start !== undefined) {
+      buffer = buffer.slice(start, start + len)
+    }
+    self.emitBody(buffer)
+    return len
+  }
+
+  parser.finish = function finish () {
+    // Parser reuse
+    if (this.socket !== self.socket) {
+      this.execute = oldExecute
+      this.finish = oldFinish
+      return this.finish()
+    }
+
+    this.execute = oldExecute
+    this.finish = oldFinish
+    self.emitMessageComplete()
+  }
+}
+
+Deceiver.prototype.emitBody = function emitBody (buffer) {
+  var parser = this.socket.parser
+  assert(parser, 'No parser present')
+
+  parser[kOnBody](buffer, 0, buffer.length)
+}
+
+Deceiver.prototype._emitEmpty = function _emitEmpty () {
+  // Emit data to force out handling of UPGRADE
+  var empty = Buffer.alloc(0)
+  if (this.socket.ondata) {
+    this.socket.ondata(empty, 0, 0)
+  } else {
+    this.socket.emit('data', empty)
+  }
+}
+
+Deceiver.prototype.emitMessageComplete = function emitMessageComplete () {
+  var parser = this.socket.parser
+  assert(parser, 'No parser present')
+
+  parser[kOnMessageComplete]()
+}

--- a/lib/spdy/deceiver.js
+++ b/lib/spdy/deceiver.js
@@ -1,10 +1,14 @@
 // Vendored from http-deceiver@1.2.7 (indutny/http-deceiver, MIT).
-// Two changes from upstream:
-//   1. The `process.binding('http_parser')` block is wrapped in try/catch
-//      and falls back to `mode = 'unsupported'`. The internal binding was
-//      removed in Node 16+ ("No such module: http_parser"); upstream is
-//      abandoned. The fallback uses string event names instead of integer
-//      kOn* indices and works for spdy's purposes.
+// Voxer changes from upstream:
+//   1. `process.binding('http_parser')` was removed in Node 16+
+//      ("No such module: http_parser"). When that fails we now load
+//      `HTTPParser` from `node:_http_common` (Node 16+) and the
+//      methods list from `require('http').METHODS`, keeping the
+//      `mode === 'modern'` numeric kOn* path. The previous fallback
+//      to `mode = 'unsupported'` used string event names that the
+//      modern parser does not expose, so `parser[kOnHeadersComplete]`
+//      was undefined and any request crashed the process with
+//      `TypeError: this[kOnHeadersComplete] is not a function`.
 //   2. `new Buffer(0)` -> `Buffer.alloc(0)` (the legacy form is removed in
 //      modern Node).
 
@@ -30,12 +34,29 @@ var kOnBody
 
 if (mode === 'normal' || mode === 'modern') {
   try {
-    HTTPParser = process.binding('http_parser').HTTPParser
+    try {
+      HTTPParser = process.binding('http_parser').HTTPParser
+    } catch (e) {
+      // Node 16+: process.binding('http_parser') is gone. The same
+      // HTTPParser constructor (with kOn* slot indices) is exported
+      // from the internal _http_common module.
+      try {
+        HTTPParser = require('node:_http_common').HTTPParser
+      } catch (e2) {
+        HTTPParser = require('_http_common').HTTPParser
+      }
+    }
     methods = HTTPParser.methods
 
     // v6
     if (!methods) {
-      methods = process.binding('http_parser').methods
+      try {
+        methods = process.binding('http_parser').methods
+      } catch (e) {
+        // Node 16+: HTTPParser does not carry .methods anymore;
+        // http.METHODS is the public, equivalent list.
+        methods = require('http').METHODS
+      }
     }
 
     reverseMethods = {}

--- a/lib/spdy/deceiver.js
+++ b/lib/spdy/deceiver.js
@@ -53,9 +53,16 @@ if (mode === 'normal' || mode === 'modern') {
       try {
         methods = process.binding('http_parser').methods
       } catch (e) {
-        // Node 16+: HTTPParser does not carry .methods anymore;
-        // http.METHODS is the public, equivalent list.
-        methods = require('http').METHODS
+        // Node 16+: HTTPParser does not carry .methods anymore.
+        // _http_common exports the parser-indexed list (DELETE, GET,
+        // HEAD, POST, ...). http.METHODS is alphabetically sorted, so
+        // using it here would shift indices and the deceiver would tell
+        // Node the wrong method (e.g. POST -> ACL).
+        try {
+          methods = require('node:_http_common').methods
+        } catch (e2) {
+          methods = require('_http_common').methods
+        }
       }
     }
 

--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -28,9 +28,18 @@ function Handle (options, stream, socket) {
   })
 
   if (!state.stream) {
+<<<<<<< HEAD
     this.on('stream', function (stream) {
       state.stream = stream
     })
+=======
+    this.on('stream', function(stream) {
+      state.stream = stream;
+      stream.on('end', function() {
+        state.ending = true;
+      });
+    });
+>>>>>>> Fixes agent to handle incoming responses correctly (#3)
   }
 }
 util.inherits(Handle, thing)

--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -28,18 +28,12 @@ function Handle (options, stream, socket) {
   })
 
   if (!state.stream) {
-<<<<<<< HEAD
     this.on('stream', function (stream) {
       state.stream = stream
+      stream.on('end', function () {
+        state.ending = true
+      })
     })
-=======
-    this.on('stream', function(stream) {
-      state.stream = stream;
-      stream.on('end', function() {
-        state.ending = true;
-      });
-    });
->>>>>>> Fixes agent to handle incoming responses correctly (#3)
   }
 }
 util.inherits(Handle, thing)

--- a/lib/spdy/handle.js
+++ b/lib/spdy/handle.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert')
 var thing = require('handle-thing')
-var httpDeceiver = require('http-deceiver')
+var httpDeceiver = require('./deceiver')
 var util = require('util')
 
 function Handle (options, stream, socket) {

--- a/lib/spdy/socket.js
+++ b/lib/spdy/socket.js
@@ -12,6 +12,7 @@ function Socket (parent, options) {
 
   state.parent = parent
 
+<<<<<<< HEAD
   this.servername = parent.servername
   this.npnProtocol = parent.npnProtocol
   this.alpnProtocol = parent.alpnProtocol
@@ -19,6 +20,15 @@ function Socket (parent, options) {
   this.authorizationError = parent.authorizationError
   this.encrypted = true
   this.allowHalfOpen = true
+=======
+  this.servername = parent.servername;
+  this.npnProtocol = parent.npnProtocol;
+  this.alpnProtocol = parent.alpnProtocol;
+  this.authorized = parent.authorized;
+  this.authorizationError = parent.authorizationError;
+  this.encrypted = true;
+  this.allowHalfOpen = true;
+>>>>>>> Add checks for GOAWAY conditions on the agent (#6)
 }
 
 util.inherits(Socket, net.Socket)

--- a/lib/spdy/socket.js
+++ b/lib/spdy/socket.js
@@ -12,7 +12,6 @@ function Socket (parent, options) {
 
   state.parent = parent
 
-<<<<<<< HEAD
   this.servername = parent.servername
   this.npnProtocol = parent.npnProtocol
   this.alpnProtocol = parent.alpnProtocol
@@ -20,15 +19,6 @@ function Socket (parent, options) {
   this.authorizationError = parent.authorizationError
   this.encrypted = true
   this.allowHalfOpen = true
-=======
-  this.servername = parent.servername;
-  this.npnProtocol = parent.npnProtocol;
-  this.alpnProtocol = parent.alpnProtocol;
-  this.authorized = parent.authorized;
-  this.authorizationError = parent.authorizationError;
-  this.encrypted = true;
-  this.allowHalfOpen = true;
->>>>>>> Add checks for GOAWAY conditions on the agent (#6)
 }
 
 util.inherits(Socket, net.Socket)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "http-deceiver": "^1.2.7",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
-    "spdy-transport": "anandsuresh/spdy-transport#fix/windowBits"
+    "spdy-transport": "anandsuresh/spdy-transport#voxer"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "http-deceiver": "^1.2.7",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
-    "spdy-transport": "^2.0.18"
+    "spdy-transport": "anandsuresh/spdy-transport#voxer"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "http-deceiver": "^1.2.7",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
-    "spdy-transport": "anandsuresh/spdy-transport#voxer"
+    "spdy-transport": "anandsuresh/spdy-transport#fix/windowBits"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "http-deceiver": "^1.2.7",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
-    "spdy-transport": "anandsuresh/spdy-transport#voxer"
+    "spdy-transport": "Voxer/spdy-transport#voxer"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "debug": "^2.6.8",
     "handle-thing": "^1.2.5",
-    "http-deceiver": "^1.2.7",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
     "spdy-transport": "Voxer/spdy-transport#voxer"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "debug": "^2.6.8",
-    "handle-thing": "^1.2.5",
+    "handle-thing": "^2.0.1",
     "safe-buffer": "^5.0.1",
     "select-hose": "^2.0.0",
     "spdy-transport": "Voxer/spdy-transport#voxer"


### PR DESCRIPTION
## Summary

Two follow-ups to #N (the deceiver fix that loaded `HTTPParser` from
`node:_http_common`). Both surfaced when bringing up `gcp2-dev03-00`
on Node 24.

### 1. handle-thing bump (`^1.2.5` → `^2.0.1`)

`handle-thing@1.2.5` calls `socket._handle.onread(nread, buffer)`.
Since Node 11.1 the handle's `onread` is
`internal/stream_base_commons.onStreamRead(arrayBuffer)`, which
reads `nread` from `streamBaseState[kReadBytesOrError]`. Passing
`UV_EOF` (`-4095`) as the arrayBuffer arg made `onStreamRead`
construct `new FastBuffer(-4095, ...)` and crash on the request's
`'end'` event:

    RangeError: Invalid typed array length: -4095
        at new FastBuffer (node:internal/buffer:956:1)
        at Handle.onStreamRead [as onread]
           (node:internal/stream_base_commons:188:19)
        at Stream.<anonymous> (.../handle-thing/lib/handle.js:120:12)

`handle-thing@2.0.1` (spdy-http2/handle-thing#13) translates the
call: it sets `streamBaseState[kReadBytesOrError]` first, then
invokes `onread` with just the buffer. It also adds `.writev`
which modern `net.Socket` needs.

### 2. Method-list source in deceiver

The previous deceiver fallback used `require('http').METHODS` for
the methods list. `http.METHODS` is **alphabetically sorted**, but
the parser's index space is the llhttp/http_parser order (DELETE,
GET, HEAD, POST, …). Sending the alphabetical index made Node
interpret POST as ACL etc.

Use `_http_common.methods` (or `node:_http_common.methods`), which
is the real parser-indexed list.

## Verification (Node v24.11.1)

`spdy.createServer` with TLS + h2 ALPN, hit with the built-in
`http2` client. Before this PR: `RangeError: Invalid typed array
length: -4095` on request end. After:
